### PR TITLE
Add Flask web UI for multi-step form workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+form_config.json
+gorev_formu_*.xlsx
+.env

--- a/web_app/__init__.py
+++ b/web_app/__init__.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import glob
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from flask import (Flask, flash, redirect, render_template, request, session,
+                   url_for)
+
+from core import form_service
+from core.form_service import FormServiceError
+
+BASE_PATH = Path(__file__).resolve().parents[1]
+DEFAULT_FORM_VALUES: Dict[str, str] = {
+    "dok_no": "F-001",
+    "rev_no": "",
+    "avans": "",
+    "taseron": "",
+    "gorev_tanimi": "",
+    "gorev_yeri": "",
+    "yola_cikis_tarih": "",
+    "yola_cikis_saat": "",
+    "donus_tarih": "",
+    "donus_saat": "",
+    "calisma_baslangic_tarih": "",
+    "calisma_baslangic_saat": "",
+    "calisma_bitis_tarih": "",
+    "calisma_bitis_saat": "",
+    "mola_suresi": "",
+    "arac_plaka": "",
+    "hazirlayan": "",
+    "durum": "YARIM",
+}
+DEFAULT_FORM_VALUES.update({f"personel_{index}": "" for index in range(1, 6)})
+
+FIELD_LABELS: Dict[str, str] = {
+    "dok_no": "DOK.NO",
+    "rev_no": "REV.NO/TRH",
+    "avans": "Avans Tutarı",
+    "taseron": "Taşeron Şirket",
+    "gorev_tanimi": "Görevin Tanımı",
+    "gorev_yeri": "Görev Yeri",
+    "yola_cikis_tarih": "Yola Çıkış Tarihi",
+    "yola_cikis_saat": "Yola Çıkış Saati",
+    "donus_tarih": "Dönüş Tarihi",
+    "donus_saat": "Dönüş Saati",
+    "calisma_baslangic_tarih": "Çalışma Başlangıç Tarihi",
+    "calisma_baslangic_saat": "Çalışma Başlangıç Saati",
+    "calisma_bitis_tarih": "Çalışma Bitiş Tarihi",
+    "calisma_bitis_saat": "Çalışma Bitiş Saati",
+    "mola_suresi": "Toplam Mola",
+    "arac_plaka": "Araç Plaka No",
+    "hazirlayan": "Hazırlayan",
+}
+
+PERSONEL_OPTIONS: List[str] = [
+    "Ahmet Yılmaz",
+    "Mehmet Demir",
+    "Ali Kaya",
+    "Veli Çelik",
+    "Hasan Şahin",
+    "Hüseyin Aydın",
+    "İbrahim Özdemir",
+    "Mustafa Arslan",
+    "Emre Doğan",
+    "Burak Yıldız",
+]
+
+TASERON_OPTIONS: List[str] = [
+    "Yok",
+    "ABC İnşaat",
+    "XYZ Teknik",
+    "Marmara Mühendislik",
+    "Anadolu Yapı",
+]
+
+HAZIRLAYAN_OPTIONS: List[str] = [
+    "Ali Yılmaz",
+    "Ayşe Demir",
+    "Mehmet Korkmaz",
+    "Zeynep Ak",
+    "Elif Kaya",
+]
+
+FORM_STEPS: List[Dict[str, str]] = [
+    {"id": "form_bilgileri", "title": "Form Bilgileri", "template": "steps/form_bilgileri.html"},
+    {"id": "gorevli_personel", "title": "Görevli Personel", "template": "steps/gorevli_personel.html"},
+    {"id": "avans_taseron", "title": "Avans ve Taşeron", "template": "steps/avans_taseron.html"},
+    {"id": "gorev_tanimi", "title": "Görev Tanımı", "template": "steps/gorev_tanimi.html"},
+    {"id": "gorev_yeri", "title": "Görev Yeri", "template": "steps/gorev_yeri.html"},
+    {"id": "saat_bilgileri", "title": "Saat Bilgileri", "template": "steps/saat_bilgileri.html"},
+    {"id": "arac_bilgisi", "title": "Araç Bilgisi", "template": "steps/arac_bilgisi.html"},
+    {"id": "hazirlayan", "title": "Hazırlayan", "template": "steps/hazirlayan.html"},
+]
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    app.secret_key = os.environ.get("FLASK_SECRET_KEY", "dev-secret-key")
+
+    register_routes(app)
+    return app
+
+
+def register_routes(app: Flask) -> None:
+    total_steps = len(FORM_STEPS)
+
+    @app.context_processor
+    def inject_globals():  # pragma: no cover - template helper
+        return {
+            "FORM_STEPS": FORM_STEPS,
+            "total_steps": total_steps,
+        }
+
+    @app.route("/")
+    def index():
+        excel_files = glob.glob(str(BASE_PATH / "gorev_formu_*.xlsx"))
+        form_numbers = sorted(
+            [Path(file).stem.replace("gorev_formu_", "") for file in excel_files],
+            reverse=True,
+        )
+        return render_template("home.html", form_numbers=form_numbers)
+
+    @app.post("/form/load")
+    def load_form_redirect():
+        form_no = request.form.get("form_no_input", "").strip() or request.form.get("form_no_select", "").strip()
+        if not form_no:
+            flash("Form numarası seçin veya girin.", "warning")
+            return redirect(url_for("index"))
+        return redirect(url_for("form_wizard", form_no=form_no, step=0))
+
+    @app.route("/form/new")
+    def new_form():
+        try:
+            form_no = form_service.get_next_form_no(base_path=str(BASE_PATH))
+        except FormServiceError as exc:
+            flash(str(exc), "error")
+            return redirect(url_for("index"))
+
+        form_data = {
+            **DEFAULT_FORM_VALUES,
+            "form_no": form_no,
+            "tarih": datetime.now().strftime("%d.%m.%Y"),
+        }
+        store_form_in_session(form_no, form_data)
+        flash(f"Yeni form oluşturuldu. Form No: {form_no}", "success")
+        return redirect(url_for("form_wizard", form_no=form_no, step=0))
+
+    @app.route("/form/<form_no>", methods=["GET", "POST"])
+    def form_wizard(form_no: str):
+        step = clamp_step(request.values.get("step", 0))
+        form_data = ensure_form_data(form_no)
+        if form_data is None:
+            flash(f"Form {form_no} yüklenemedi.", "error")
+            return redirect(url_for("index"))
+
+        current_step = FORM_STEPS[step]
+
+        if request.method == "POST":
+            update_form_data_from_request(form_data, current_step["id"], request.form)
+            store_form_in_session(form_no, form_data)
+
+            action = request.form.get("action")
+            if action == "previous":
+                previous_step = max(0, step - 1)
+                return redirect(url_for("form_wizard", form_no=form_no, step=previous_step))
+            if action == "save":
+                try:
+                    filename, status = form_service.save_form(form_no, form_data, base_path=str(BASE_PATH))
+                except FormServiceError as exc:
+                    flash(str(exc), "error")
+                else:
+                    form_data["durum"] = status.code
+                    store_form_in_session(form_no, form_data)
+                    flash(f"Form {status.code} olarak kaydedildi. Dosya: {filename}", "success")
+                return redirect(url_for("form_wizard", form_no=form_no, step=step))
+
+            next_step = step + 1
+            if next_step >= total_steps:
+                return redirect(url_for("form_summary", form_no=form_no))
+            return redirect(url_for("form_wizard", form_no=form_no, step=next_step))
+
+        return render_template(
+            current_step["template"],
+            form_no=form_no,
+            form_data=form_data,
+            step_index=step,
+            personel_options=PERSONEL_OPTIONS,
+            taseron_options=TASERON_OPTIONS,
+            hazirlayan_options=HAZIRLAYAN_OPTIONS,
+        )
+
+    @app.route("/form/<form_no>/summary", methods=["GET", "POST"])
+    def form_summary(form_no: str):
+        form_data = ensure_form_data(form_no)
+        if form_data is None:
+            flash(f"Form {form_no} yüklenemedi.", "error")
+            return redirect(url_for("index"))
+
+        status = form_service.determine_form_status(form_data)
+        form_data["durum"] = status.code
+        store_form_in_session(form_no, form_data)
+
+        if request.method == "POST":
+            action = request.form.get("action")
+            if action == "save":
+                try:
+                    filename, status = form_service.save_form(form_no, form_data, base_path=str(BASE_PATH))
+                except FormServiceError as exc:
+                    flash(str(exc), "error")
+                else:
+                    form_data["durum"] = status.code
+                    store_form_in_session(form_no, form_data)
+                    flash(f"Form {status.code} olarak kaydedildi. Dosya: {filename}", "success")
+                return redirect(url_for("form_summary", form_no=form_no))
+            if action == "previous":
+                return redirect(url_for("form_wizard", form_no=form_no, step=total_steps - 1))
+
+        missing_fields = [
+            FIELD_LABELS.get(field, field.replace("_", " ").title())
+            for field in status.missing_fields
+        ]
+
+        return render_template(
+            "summary.html",
+            form_no=form_no,
+            form_data=form_data,
+            status=status,
+            missing_fields=missing_fields,
+        )
+
+    def clamp_step(step_value) -> int:
+        try:
+            value = int(step_value)
+        except (ValueError, TypeError):
+            return 0
+        return max(0, min(value, total_steps - 1))
+
+    def ensure_form_data(form_no: str):
+        forms = session.get("forms", {})
+        form_data = forms.get(form_no)
+        if form_data:
+            return form_data
+        try:
+            loaded = form_service.load_form_data(form_no, base_path=str(BASE_PATH))
+        except FormServiceError as exc:
+            flash(str(exc), "error")
+            return None
+        else:
+            store_form_in_session(form_no, loaded)
+            return loaded
+
+    def store_form_in_session(form_no: str, form_data: Dict[str, str]) -> None:
+        forms = session.get("forms", {})
+        forms[form_no] = form_data
+        session["forms"] = forms
+
+    def update_form_data_from_request(form_data: Dict[str, str], step_id: str, data) -> None:
+        if step_id == "form_bilgileri":
+            form_data["dok_no"] = data.get("dok_no", "").strip()
+            form_data["rev_no"] = data.get("rev_no", "").strip()
+            tarih = data.get("tarih", "").strip()
+            if tarih:
+                form_data["tarih"] = tarih
+        elif step_id == "gorevli_personel":
+            for index in range(1, 6):
+                form_data[f"personel_{index}"] = data.get(f"personel_{index}", "").strip()
+        elif step_id == "avans_taseron":
+            form_data["avans"] = data.get("avans", "").strip()
+            form_data["taseron"] = data.get("taseron", "").strip()
+        elif step_id == "gorev_tanimi":
+            form_data["gorev_tanimi"] = data.get("gorev_tanimi", "").strip()
+        elif step_id == "gorev_yeri":
+            form_data["gorev_yeri"] = data.get("gorev_yeri", "").strip()
+        elif step_id == "saat_bilgileri":
+            for field in [
+                "yola_cikis_tarih",
+                "yola_cikis_saat",
+                "donus_tarih",
+                "donus_saat",
+                "calisma_baslangic_tarih",
+                "calisma_baslangic_saat",
+                "calisma_bitis_tarih",
+                "calisma_bitis_saat",
+                "mola_suresi",
+            ]:
+                form_data[field] = data.get(field, "").strip()
+        elif step_id == "arac_bilgisi":
+            form_data["arac_plaka"] = data.get("arac_plaka", "").strip()
+        elif step_id == "hazirlayan":
+            form_data["hazirlayan"] = data.get("hazirlayan", "").strip()
+
+    app.jinja_env.globals.update(
+        PERSONEL_OPTIONS=PERSONEL_OPTIONS,
+        TASERON_OPTIONS=TASERON_OPTIONS,
+        HAZIRLAYAN_OPTIONS=HAZIRLAYAN_OPTIONS,
+        FIELD_LABELS=FIELD_LABELS,
+        datetime=datetime,
+    )
+
+
+app = create_app()
+
+
+__all__ = ["app", "create_app"]

--- a/web_app/static/styles.css
+++ b/web_app/static/styles.css
@@ -1,0 +1,459 @@
+:root {
+    --primary: #0d47a1;
+    --secondary: #ff9800;
+    --accent: #4dd0e1;
+    --danger: #d32f2f;
+    --success: #4caf50;
+    --warning: #ffc107;
+    --bg: #f5f5f5;
+    --card-bg: #ffffff;
+    --border: #dfe4ea;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: 'Segoe UI', Tahoma, sans-serif;
+    background: var(--bg);
+    color: #1f2933;
+}
+
+.container {
+    width: min(1100px, 92%);
+    margin: 0 auto;
+}
+
+.app-header {
+    background: var(--card-bg);
+    border-bottom: 1px solid var(--border);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.app-header h1 {
+    margin: 0;
+    padding: 20px 0 10px;
+    color: var(--danger);
+    font-size: 1.6rem;
+}
+
+.app-header nav {
+    padding-bottom: 15px;
+}
+
+.app-header nav a {
+    margin-right: 16px;
+    color: var(--primary);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.app-header nav a:hover {
+    text-decoration: underline;
+}
+
+.app-footer {
+    text-align: center;
+    padding: 30px 0;
+    color: #6b7280;
+}
+
+.flash-container {
+    margin: 25px 0 10px;
+}
+
+.flash {
+    padding: 12px 18px;
+    border-radius: 10px;
+    margin-bottom: 10px;
+    font-weight: 600;
+}
+
+.flash-success {
+    background: #e8f5e9;
+    color: #1b5e20;
+    border: 1px solid #a5d6a7;
+}
+
+.flash-warning {
+    background: #fff8e1;
+    color: #8d6e63;
+    border: 1px solid #ffe082;
+}
+
+.flash-error {
+    background: #ffebee;
+    color: #b71c1c;
+    border: 1px solid #ef9a9a;
+}
+
+.menu-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 24px;
+    margin: 40px 0;
+}
+
+.menu-card {
+    background: var(--card-bg);
+    border-radius: 16px;
+    padding: 24px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    position: relative;
+    overflow: hidden;
+}
+
+.menu-card h2 {
+    margin-top: 0;
+}
+
+.menu-card.accent-blue::before,
+.menu-card.accent-yellow::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    opacity: 0.15;
+    pointer-events: none;
+}
+
+.menu-card.accent-blue::before {
+    background: linear-gradient(135deg, var(--accent), #81d4fa);
+}
+
+.menu-card.accent-yellow::before {
+    background: linear-gradient(135deg, #fff176, var(--secondary));
+}
+
+.menu-card .button {
+    margin-top: 18px;
+}
+
+.form-inline {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+}
+
+.form-inline label {
+    font-weight: 600;
+}
+
+.form-inline select,
+.form-inline input[type="text"] {
+    padding: 10px 12px;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    min-width: 160px;
+}
+
+.divider {
+    font-size: 0.85rem;
+    color: #6b7280;
+}
+
+.button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 12px 22px;
+    border-radius: 10px;
+    border: none;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform 0.2s, box-shadow 0.2s;
+    text-decoration: none;
+}
+
+.button.primary {
+    background: var(--primary);
+    color: #fff;
+    box-shadow: 0 8px 18px rgba(13, 71, 161, 0.25);
+}
+
+.button.secondary {
+    background: var(--secondary);
+    color: #fff;
+    box-shadow: 0 8px 18px rgba(255, 152, 0, 0.25);
+}
+
+.button.save {
+    background: var(--success);
+    color: #fff;
+    box-shadow: 0 8px 18px rgba(76, 175, 80, 0.25);
+}
+
+.button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 22px rgba(0, 0, 0, 0.12);
+}
+
+.step-indicator {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin: 35px 0 25px;
+}
+
+.step-indicator .step {
+    flex: 1 1 150px;
+    background: var(--card-bg);
+    border-radius: 12px;
+    padding: 12px;
+    border: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+}
+
+.step-indicator .step .step-number {
+    background: var(--accent);
+    color: #0f172a;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+}
+
+.step-indicator .step.active {
+    border-color: var(--primary);
+}
+
+.step-indicator .step.active .step-number {
+    background: var(--primary);
+    color: #fff;
+}
+
+.step-indicator .step.complete {
+    border-color: #a5d6a7;
+}
+
+.step-indicator .step.complete .step-number {
+    background: var(--success);
+    color: #fff;
+}
+
+.form-card {
+    background: var(--card-bg);
+    border-radius: 16px;
+    padding: 28px;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);
+    margin-bottom: 40px;
+}
+
+.form-card.form-scroll {
+    max-height: 600px;
+    overflow-y: auto;
+}
+
+.form-row {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 18px;
+}
+
+.form-row label {
+    font-weight: 600;
+    margin-bottom: 6px;
+}
+
+.form-row input,
+.form-row select,
+.form-row textarea {
+    padding: 12px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    font-size: 1rem;
+}
+
+.form-row textarea {
+    min-height: 160px;
+    resize: vertical;
+}
+
+.form-actions {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+    margin-top: 24px;
+}
+
+.grid {
+    display: grid;
+    gap: 18px;
+}
+
+.grid-2 {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.personel-select.duplicate {
+    border-color: var(--danger);
+    background: #fdecea;
+}
+
+.summary-card {
+    background: var(--card-bg);
+    border-radius: 20px;
+    box-shadow: 0 16px 40px rgba(13, 71, 161, 0.12);
+    padding: 0 0 24px;
+    overflow: hidden;
+}
+
+.summary-header {
+    display: flex;
+    gap: 24px;
+    background: linear-gradient(135deg, #e3f2fd, #bbdefb);
+    padding: 28px 32px;
+    align-items: center;
+}
+
+.summary-header .brand {
+    font-size: 1rem;
+    color: var(--danger);
+    text-align: center;
+}
+
+.summary-header .form-title {
+    flex: 1;
+    text-align: center;
+    font-size: 2rem;
+    font-weight: 700;
+    color: #0f172a;
+    background: var(--primary);
+    color: #fff;
+    padding: 12px 18px;
+    border-radius: 12px;
+}
+
+.summary-header .form-meta {
+    min-width: 180px;
+    background: #fffde7;
+    border-radius: 12px;
+    padding: 12px;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+}
+
+.summary-header .meta-row {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 6px;
+    font-weight: 600;
+}
+
+.summary-header .meta-row span {
+    color: #555;
+}
+
+.summary-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+}
+
+.summary-table th,
+.summary-table td {
+    border: 1px solid #cfd8dc;
+    padding: 12px 16px;
+    text-align: left;
+    vertical-align: top;
+}
+
+.summary-table .section th {
+    background: #fff176;
+    color: #000;
+    text-transform: uppercase;
+    font-size: 0.9rem;
+}
+
+.summary-table .label {
+    background: #fffde7;
+    width: 200px;
+}
+
+.summary-table tr:nth-child(even) td {
+    background: #fafafa;
+}
+
+.summary-table tr:nth-child(odd) td {
+    background: #ffffff;
+}
+
+.summary-table tr.status-row th,
+.summary-table tr.status-row td {
+    text-align: center;
+    font-size: 1.1rem;
+    font-weight: 700;
+}
+
+.summary-table tr.status-row.status-complete th,
+.summary-table tr.status-row.status-complete td {
+    background: var(--success);
+    color: #fff;
+}
+
+.summary-table tr.status-row.status-partial th {
+    background: var(--secondary);
+    color: #fff;
+}
+
+.summary-table tr.status-row.status-partial td {
+    background: #ffe082;
+    color: #bf360c;
+}
+
+.summary-table tr.status-row.status-complete td {
+    background: #c8e6c9;
+    color: #1b5e20;
+}
+
+.missing-fields {
+    margin: 18px 32px 0;
+    padding: 16px 20px;
+    background: #fff8e1;
+    border-radius: 12px;
+    border: 1px solid #ffe082;
+}
+
+.missing-fields ul {
+    margin: 8px 0 0 18px;
+}
+
+.summary-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    margin: 24px 32px 0;
+}
+
+@media (max-width: 768px) {
+    .step-indicator .step {
+        flex: 1 1 100%;
+    }
+
+    .form-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .summary-header {
+        flex-direction: column;
+        align-items: stretch;
+        text-align: center;
+    }
+
+    .summary-header .form-meta {
+        width: 100%;
+    }
+
+    .summary-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}

--- a/web_app/templates/base.html
+++ b/web_app/templates/base.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}Görev Formu Sistemi{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+<header class="app-header">
+    <div class="container">
+        <h1>🔧 Delta Proje &mdash; Görev Formu Sistemi</h1>
+        <nav>
+            <a href="{{ url_for('index') }}">Ana Menü</a>
+            {% if form_no %}
+            <a href="{{ url_for('form_wizard', form_no=form_no, step=0) }}">Form {{ form_no }}</a>
+            <a href="{{ url_for('form_summary', form_no=form_no) }}">Özet</a>
+            {% endif %}
+        </nav>
+    </div>
+</header>
+<main class="container">
+    {% with messages = get_flashed_messages(with_categories=True) %}
+        {% if messages %}
+            <div class="flash-container">
+                {% for category, message in messages %}
+                    <div class="flash flash-{{ category }}">{{ message }}</div>
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
+
+    {% block steps %}{% endblock %}
+
+    <section class="content">
+        {% block content %}{% endblock %}
+    </section>
+</main>
+<footer class="app-footer">
+    <div class="container">
+        <small>&copy; {{ datetime.utcnow().year }} Delta Proje</small>
+    </div>
+</footer>
+<script>
+    document.querySelectorAll('[data-action="submit-step"]').forEach(function(button) {
+        button.addEventListener('click', function (event) {
+            var form = button.closest('form');
+            if (form) {
+                var actionInput = form.querySelector('input[name="action"]');
+                if (actionInput) {
+                    actionInput.value = button.dataset.value;
+                }
+            }
+        });
+    });
+</script>
+{% block scripts %}{% endblock %}
+</body>
+</html>

--- a/web_app/templates/home.html
+++ b/web_app/templates/home.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block title %}Ana Menü · Görev Formu Sistemi{% endblock %}
+
+{% block content %}
+<div class="menu-grid">
+    <div class="menu-card accent-blue">
+        <h2>📝 Yeni Görev Oluştur</h2>
+        <p>Yeni bir görev formu numarası alarak adım adım formu doldurun.</p>
+        <a class="button primary" href="{{ url_for('new_form') }}">Yeni Form Başlat</a>
+    </div>
+    <div class="menu-card accent-yellow">
+        <h2>📂 Görev Formu Çağır</h2>
+        <p>Var olan bir form numarasını seçerek kaldığınız yerden devam edin.</p>
+        <form method="post" action="{{ url_for('load_form_redirect') }}" class="form-inline">
+            <label for="form_no_select">Form No</label>
+            <select id="form_no_select" name="form_no_select">
+                <option value="">Form seçin...</option>
+                {% for number in form_numbers %}
+                    <option value="{{ number }}">{{ number }}</option>
+                {% endfor %}
+            </select>
+            <div class="divider">veya</div>
+            <input type="text" name="form_no_input" placeholder="Form no girin">
+            <button type="submit" class="button secondary">Formu Aç</button>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/web_app/templates/steps/arac_bilgisi.html
+++ b/web_app/templates/steps/arac_bilgisi.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}Form {{ form_no }} · Araç Bilgisi{% endblock %}
+
+{% block steps %}
+<div class="step-indicator">
+    {% for step in FORM_STEPS %}
+        <div class="step {{ 'active' if loop.index0 == step_index else '' }} {{ 'complete' if loop.index0 < step_index else '' }}">
+            <span class="step-number">{{ loop.index }}</span>
+            <span class="step-title">{{ step.title }}</span>
+        </div>
+    {% endfor %}
+</div>
+{% endblock %}
+
+{% block content %}
+<h2>🚐 Araç Bilgisi</h2>
+<form method="post" action="{{ url_for('form_wizard', form_no=form_no, step=step_index) }}" class="form-card">
+    <input type="hidden" name="action" value="next">
+    <div class="form-row">
+        <label for="arac_plaka">Araç Plaka No</label>
+        <input id="arac_plaka" name="arac_plaka" type="text" value="{{ form_data.get('arac_plaka', '') }}" placeholder="34 ABC 123">
+    </div>
+    <div class="form-actions">
+        <button type="submit" class="button secondary" data-action="submit-step" data-value="previous">← Geri</button>
+        <button type="submit" class="button save" data-action="submit-step" data-value="save">💾 Kaydet</button>
+        <button type="submit" class="button primary" data-action="submit-step" data-value="next">İleri →</button>
+    </div>
+</form>
+{% endblock %}

--- a/web_app/templates/steps/avans_taseron.html
+++ b/web_app/templates/steps/avans_taseron.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% block title %}Form {{ form_no }} · Avans ve Taşeron{% endblock %}
+
+{% block steps %}
+<div class="step-indicator">
+    {% for step in FORM_STEPS %}
+        <div class="step {{ 'active' if loop.index0 == step_index else '' }} {{ 'complete' if loop.index0 < step_index else '' }}">
+            <span class="step-number">{{ loop.index }}</span>
+            <span class="step-title">{{ step.title }}</span>
+        </div>
+    {% endfor %}
+</div>
+{% endblock %}
+
+{% block content %}
+<h2>💰 Avans ve Taşeron Bilgileri</h2>
+<form method="post" action="{{ url_for('form_wizard', form_no=form_no, step=step_index) }}" class="form-card">
+    <input type="hidden" name="action" value="next">
+    <div class="form-row">
+        <label for="avans">Avans Tutarı</label>
+        <input id="avans" name="avans" type="text" value="{{ form_data.get('avans', '') }}" placeholder="Örn. 1500 TL">
+    </div>
+    <div class="form-row">
+        <label for="taseron">Taşeron Şirket</label>
+        <select id="taseron" name="taseron">
+            <option value="">Seçiniz</option>
+            {% for option in taseron_options %}
+                <option value="{{ option }}" {% if form_data.get('taseron') == option %}selected{% endif %}>{{ option }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="form-actions">
+        <button type="submit" class="button secondary" data-action="submit-step" data-value="previous">← Geri</button>
+        <button type="submit" class="button save" data-action="submit-step" data-value="save">💾 Kaydet</button>
+        <button type="submit" class="button primary" data-action="submit-step" data-value="next">İleri →</button>
+    </div>
+</form>
+{% endblock %}

--- a/web_app/templates/steps/form_bilgileri.html
+++ b/web_app/templates/steps/form_bilgileri.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% block title %}Form {{ form_no }} · Form Bilgileri{% endblock %}
+
+{% block steps %}
+<div class="step-indicator">
+    {% for step in FORM_STEPS %}
+        <div class="step {{ 'active' if loop.index0 == step_index else '' }} {{ 'complete' if loop.index0 < step_index else '' }}">
+            <span class="step-number">{{ loop.index }}</span>
+            <span class="step-title">{{ step.title }}</span>
+        </div>
+    {% endfor %}
+</div>
+{% endblock %}
+
+{% block content %}
+<h2>📋 Form Bilgileri</h2>
+<form method="post" action="{{ url_for('form_wizard', form_no=form_no, step=step_index) }}" class="form-card">
+    <input type="hidden" name="action" value="next">
+    <div class="form-row">
+        <label>Form No</label>
+        <input type="text" value="{{ form_no }}" readonly>
+    </div>
+    <div class="form-row">
+        <label for="tarih">Tarih</label>
+        <input id="tarih" name="tarih" type="text" value="{{ form_data.get('tarih', '') }}" placeholder="GG.AA.YYYY">
+    </div>
+    <div class="form-row">
+        <label for="dok_no">DOK.NO</label>
+        <input id="dok_no" name="dok_no" type="text" value="{{ form_data.get('dok_no', '') }}" required>
+    </div>
+    <div class="form-row">
+        <label for="rev_no">REV.NO/TRH</label>
+        <input id="rev_no" name="rev_no" type="text" value="{{ form_data.get('rev_no', '') }}">
+    </div>
+    <div class="form-actions">
+        <button type="submit" class="button save" data-action="submit-step" data-value="save">💾 Kaydet</button>
+        <button type="submit" class="button primary" data-action="submit-step" data-value="next">İleri →</button>
+    </div>
+</form>
+{% endblock %}

--- a/web_app/templates/steps/gorev_tanimi.html
+++ b/web_app/templates/steps/gorev_tanimi.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}Form {{ form_no }} · Görev Tanımı{% endblock %}
+
+{% block steps %}
+<div class="step-indicator">
+    {% for step in FORM_STEPS %}
+        <div class="step {{ 'active' if loop.index0 == step_index else '' }} {{ 'complete' if loop.index0 < step_index else '' }}">
+            <span class="step-number">{{ loop.index }}</span>
+            <span class="step-title">{{ step.title }}</span>
+        </div>
+    {% endfor %}
+</div>
+{% endblock %}
+
+{% block content %}
+<h2>📝 Görevin Tanımı</h2>
+<form method="post" action="{{ url_for('form_wizard', form_no=form_no, step=step_index) }}" class="form-card">
+    <input type="hidden" name="action" value="next">
+    <div class="form-row">
+        <label for="gorev_tanimi">Görev Detayı</label>
+        <textarea id="gorev_tanimi" name="gorev_tanimi" rows="10" placeholder="Görev kapsamını ayrıntılı şekilde yazınız">{{ form_data.get('gorev_tanimi', '') }}</textarea>
+    </div>
+    <div class="form-actions">
+        <button type="submit" class="button secondary" data-action="submit-step" data-value="previous">← Geri</button>
+        <button type="submit" class="button save" data-action="submit-step" data-value="save">💾 Kaydet</button>
+        <button type="submit" class="button primary" data-action="submit-step" data-value="next">İleri →</button>
+    </div>
+</form>
+{% endblock %}

--- a/web_app/templates/steps/gorev_yeri.html
+++ b/web_app/templates/steps/gorev_yeri.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}Form {{ form_no }} · Görev Yeri{% endblock %}
+
+{% block steps %}
+<div class="step-indicator">
+    {% for step in FORM_STEPS %}
+        <div class="step {{ 'active' if loop.index0 == step_index else '' }} {{ 'complete' if loop.index0 < step_index else '' }}">
+            <span class="step-number">{{ loop.index }}</span>
+            <span class="step-title">{{ step.title }}</span>
+        </div>
+    {% endfor %}
+</div>
+{% endblock %}
+
+{% block content %}
+<h2>📍 Görev Yeri</h2>
+<form method="post" action="{{ url_for('form_wizard', form_no=form_no, step=step_index) }}" class="form-card">
+    <input type="hidden" name="action" value="next">
+    <div class="form-row">
+        <label for="gorev_yeri">Görev Yeri</label>
+        <textarea id="gorev_yeri" name="gorev_yeri" rows="8" placeholder="Görev konumu ve saha bilgilerini yazınız">{{ form_data.get('gorev_yeri', '') }}</textarea>
+    </div>
+    <div class="form-actions">
+        <button type="submit" class="button secondary" data-action="submit-step" data-value="previous">← Geri</button>
+        <button type="submit" class="button save" data-action="submit-step" data-value="save">💾 Kaydet</button>
+        <button type="submit" class="button primary" data-action="submit-step" data-value="next">İleri →</button>
+    </div>
+</form>
+{% endblock %}

--- a/web_app/templates/steps/gorevli_personel.html
+++ b/web_app/templates/steps/gorevli_personel.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+{% block title %}Form {{ form_no }} · Görevli Personel{% endblock %}
+
+{% block steps %}
+<div class="step-indicator">
+    {% for step in FORM_STEPS %}
+        <div class="step {{ 'active' if loop.index0 == step_index else '' }} {{ 'complete' if loop.index0 < step_index else '' }}">
+            <span class="step-number">{{ loop.index }}</span>
+            <span class="step-title">{{ step.title }}</span>
+        </div>
+    {% endfor %}
+</div>
+{% endblock %}
+
+{% block content %}
+<h2>👥 Görevli Personel</h2>
+<form method="post" action="{{ url_for('form_wizard', form_no=form_no, step=step_index) }}" class="form-card">
+    <input type="hidden" name="action" value="next">
+    {% for index in range(1, 6) %}
+    <div class="form-row">
+        <label for="personel_{{ index }}">Personel {{ index }}</label>
+        <select id="personel_{{ index }}" name="personel_{{ index }}" class="personel-select">
+            <option value="">Seçiniz</option>
+            {% for option in personel_options %}
+                <option value="{{ option }}" {% if form_data.get('personel_' ~ index) == option %}selected{% endif %}>{{ option }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    {% endfor %}
+    <div class="form-actions">
+        <button type="submit" class="button secondary" data-action="submit-step" data-value="previous">← Geri</button>
+        <button type="submit" class="button save" data-action="submit-step" data-value="save">💾 Kaydet</button>
+        <button type="submit" class="button primary" data-action="submit-step" data-value="next">İleri →</button>
+    </div>
+</form>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    const selects = document.querySelectorAll('.personel-select');
+    selects.forEach(select => {
+        select.addEventListener('change', function() {
+            const values = Array.from(selects).map(el => el.value).filter(Boolean);
+            const duplicates = values.filter((value, index, arr) => arr.indexOf(value) !== index);
+            selects.forEach(el => el.classList.remove('duplicate'));
+            if (duplicates.length) {
+                selects.forEach(el => {
+                    if (duplicates.includes(el.value)) {
+                        el.classList.add('duplicate');
+                    }
+                });
+            }
+        });
+    });
+    selects.forEach(select => select.dispatchEvent(new Event('change')));
+</script>
+{% endblock %}

--- a/web_app/templates/steps/hazirlayan.html
+++ b/web_app/templates/steps/hazirlayan.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block title %}Form {{ form_no }} · Hazırlayan{% endblock %}
+
+{% block steps %}
+<div class="step-indicator">
+    {% for step in FORM_STEPS %}
+        <div class="step {{ 'active' if loop.index0 == step_index else '' }} {{ 'complete' if loop.index0 < step_index else '' }}">
+            <span class="step-number">{{ loop.index }}</span>
+            <span class="step-title">{{ step.title }}</span>
+        </div>
+    {% endfor %}
+</div>
+{% endblock %}
+
+{% block content %}
+<h2>✍️ Hazırlayan / Görevlendiren</h2>
+<form method="post" action="{{ url_for('form_wizard', form_no=form_no, step=step_index) }}" class="form-card">
+    <input type="hidden" name="action" value="next">
+    <div class="form-row">
+        <label for="hazirlayan">Hazırlayan</label>
+        <select id="hazirlayan" name="hazirlayan">
+            <option value="">Seçiniz</option>
+            {% for option in hazirlayan_options %}
+                <option value="{{ option }}" {% if form_data.get('hazirlayan') == option %}selected{% endif %}>{{ option }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="form-actions">
+        <button type="submit" class="button secondary" data-action="submit-step" data-value="previous">← Geri</button>
+        <button type="submit" class="button save" data-action="submit-step" data-value="save">💾 Kaydet</button>
+        <button type="submit" class="button primary" data-action="submit-step" data-value="next">Özete Git →</button>
+    </div>
+</form>
+{% endblock %}

--- a/web_app/templates/steps/saat_bilgileri.html
+++ b/web_app/templates/steps/saat_bilgileri.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+{% block title %}Form {{ form_no }} · Saat Bilgileri{% endblock %}
+
+{% block steps %}
+<div class="step-indicator">
+    {% for step in FORM_STEPS %}
+        <div class="step {{ 'active' if loop.index0 == step_index else '' }} {{ 'complete' if loop.index0 < step_index else '' }}">
+            <span class="step-number">{{ loop.index }}</span>
+            <span class="step-title">{{ step.title }}</span>
+        </div>
+    {% endfor %}
+</div>
+{% endblock %}
+
+{% block content %}
+<h2>🕐 Saat ve Tarih Bilgileri</h2>
+<form method="post" action="{{ url_for('form_wizard', form_no=form_no, step=step_index) }}" class="form-card form-scroll">
+    <input type="hidden" name="action" value="next">
+    <div class="grid grid-2">
+        <div class="form-row">
+            <label for="yola_cikis_tarih">Yola Çıkış Tarihi</label>
+            <input id="yola_cikis_tarih" name="yola_cikis_tarih" type="text" value="{{ form_data.get('yola_cikis_tarih', '') }}" placeholder="GG.AA.YYYY">
+        </div>
+        <div class="form-row">
+            <label for="yola_cikis_saat">Yola Çıkış Saati</label>
+            <input id="yola_cikis_saat" name="yola_cikis_saat" type="text" value="{{ form_data.get('yola_cikis_saat', '') }}" placeholder="SS:DD">
+        </div>
+        <div class="form-row">
+            <label for="donus_tarih">Dönüş Tarihi</label>
+            <input id="donus_tarih" name="donus_tarih" type="text" value="{{ form_data.get('donus_tarih', '') }}" placeholder="GG.AA.YYYY">
+        </div>
+        <div class="form-row">
+            <label for="donus_saat">Dönüş Saati</label>
+            <input id="donus_saat" name="donus_saat" type="text" value="{{ form_data.get('donus_saat', '') }}" placeholder="SS:DD">
+        </div>
+        <div class="form-row">
+            <label for="calisma_baslangic_tarih">Çalışma Başlangıç Tarihi</label>
+            <input id="calisma_baslangic_tarih" name="calisma_baslangic_tarih" type="text" value="{{ form_data.get('calisma_baslangic_tarih', '') }}" placeholder="GG.AA.YYYY">
+        </div>
+        <div class="form-row">
+            <label for="calisma_baslangic_saat">Çalışma Başlangıç Saati</label>
+            <input id="calisma_baslangic_saat" name="calisma_baslangic_saat" type="text" value="{{ form_data.get('calisma_baslangic_saat', '') }}" placeholder="SS:DD">
+        </div>
+        <div class="form-row">
+            <label for="calisma_bitis_tarih">Çalışma Bitiş Tarihi</label>
+            <input id="calisma_bitis_tarih" name="calisma_bitis_tarih" type="text" value="{{ form_data.get('calisma_bitis_tarih', '') }}" placeholder="GG.AA.YYYY">
+        </div>
+        <div class="form-row">
+            <label for="calisma_bitis_saat">Çalışma Bitiş Saati</label>
+            <input id="calisma_bitis_saat" name="calisma_bitis_saat" type="text" value="{{ form_data.get('calisma_bitis_saat', '') }}" placeholder="SS:DD">
+        </div>
+        <div class="form-row">
+            <label for="mola_suresi">Toplam Mola (dakika)</label>
+            <input id="mola_suresi" name="mola_suresi" type="number" min="0" step="5" value="{{ form_data.get('mola_suresi', '') }}">
+        </div>
+    </div>
+    <div class="form-actions">
+        <button type="submit" class="button secondary" data-action="submit-step" data-value="previous">← Geri</button>
+        <button type="submit" class="button save" data-action="submit-step" data-value="save">💾 Kaydet</button>
+        <button type="submit" class="button primary" data-action="submit-step" data-value="next">İleri →</button>
+    </div>
+</form>
+{% endblock %}

--- a/web_app/templates/summary.html
+++ b/web_app/templates/summary.html
@@ -1,0 +1,126 @@
+{% extends "base.html" %}
+{% block title %}Form {{ form_no }} · Özet{% endblock %}
+
+{% block steps %}
+<div class="step-indicator">
+    {% for step in FORM_STEPS %}
+        <div class="step {{ 'complete' }}">
+            <span class="step-number">{{ loop.index }}</span>
+            <span class="step-title">{{ step.title }}</span>
+        </div>
+    {% endfor %}
+    <div class="step active">
+        <span class="step-number">Ö</span>
+        <span class="step-title">Özet</span>
+    </div>
+</div>
+{% endblock %}
+
+{% block content %}
+<h2>📊 Form Özeti</h2>
+<div class="summary-card">
+    <div class="summary-header">
+        <div class="brand">
+            <strong>Delta Proje<br>Hidrolik &amp; Pnömatik</strong>
+        </div>
+        <div class="form-title">GÖREV FORMU</div>
+        <div class="form-meta">
+            <div class="meta-row"><span>FORM NO</span><strong>{{ form_no }}</strong></div>
+            <div class="meta-row"><span>TARİH</span><strong>{{ form_data.get('tarih', '-') or '-' }}</strong></div>
+            <div class="meta-row"><span>DOK.NO</span><strong>{{ form_data.get('dok_no', '-') or '-' }}</strong></div>
+            <div class="meta-row"><span>REV.NO/TRH</span><strong>{{ form_data.get('rev_no', '-') or '-' }}</strong></div>
+        </div>
+    </div>
+    <table class="summary-table">
+        <tbody>
+            <tr class="section">
+                <th colspan="2">GÖREVLİ PERSONEL</th>
+                <th colspan="2">AVANS TUTARI</th>
+                <th colspan="2">TAŞERON ŞİRKET</th>
+            </tr>
+            {% for index in range(1, 6) %}
+            <tr>
+                <td colspan="2">{{ form_data.get('personel_' ~ index, '') or '-' }}</td>
+                {% if loop.first %}
+                <td colspan="2" rowspan="5">{{ form_data.get('avans', '') or '-' }}</td>
+                <td colspan="2" rowspan="5">{{ form_data.get('taseron', '') or '-' }}</td>
+                {% endif %}
+            </tr>
+            {% endfor %}
+            <tr class="section">
+                <th colspan="6">GÖREV VE SAHA BİLGİLERİ</th>
+            </tr>
+            <tr>
+                <th class="label">Görevin Tanımı</th>
+                <td colspan="5">{{ form_data.get('gorev_tanimi', '') or '-' }}</td>
+            </tr>
+            <tr>
+                <th class="label">Görev Yeri</th>
+                <td colspan="5">{{ form_data.get('gorev_yeri', '') or '-' }}</td>
+            </tr>
+            <tr class="section">
+                <th colspan="6">SEYAHAT / ÇALIŞMA BİLGİLERİ</th>
+            </tr>
+            <tr>
+                <th class="label">Yola Çıkış Tarihi</th>
+                <td>{{ form_data.get('yola_cikis_tarih', '') or '-' }}</td>
+                <th class="label">Yola Çıkış Saati</th>
+                <td>{{ form_data.get('yola_cikis_saat', '') or '-' }}</td>
+                <td colspan="2"></td>
+            </tr>
+            <tr>
+                <th class="label">Dönüş Tarihi</th>
+                <td>{{ form_data.get('donus_tarih', '') or '-' }}</td>
+                <th class="label">Dönüş Saati</th>
+                <td>{{ form_data.get('donus_saat', '') or '-' }}</td>
+                <td colspan="2"></td>
+            </tr>
+            <tr>
+                <th class="label">Çalışma Başlangıç</th>
+                <td>{{ form_data.get('calisma_baslangic_tarih', '') or '-' }}</td>
+                <th class="label">Başlangıç Saati</th>
+                <td>{{ form_data.get('calisma_baslangic_saat', '') or '-' }}</td>
+                <td colspan="2"></td>
+            </tr>
+            <tr>
+                <th class="label">Çalışma Bitiş</th>
+                <td>{{ form_data.get('calisma_bitis_tarih', '') or '-' }}</td>
+                <th class="label">Bitiş Saati</th>
+                <td>{{ form_data.get('calisma_bitis_saat', '') or '-' }}</td>
+                <td colspan="2"></td>
+            </tr>
+            <tr>
+                <th class="label">Toplam Mola</th>
+                <td colspan="5">{% if form_data.get('mola_suresi') %}{{ form_data.get('mola_suresi') }} dakika{% else %}-{% endif %}</td>
+            </tr>
+            <tr class="section">
+                <th colspan="3">ARAÇ PLAKA NO</th>
+                <th colspan="3">HAZIRLAYAN / GÖREVLENDİREN</th>
+            </tr>
+            <tr>
+                <td colspan="3">{{ form_data.get('arac_plaka', '') or '-' }}</td>
+                <td colspan="3">{{ form_data.get('hazirlayan', '') or '-' }}</td>
+            </tr>
+            <tr class="status-row {{ 'status-complete' if status.is_complete else 'status-partial' }}">
+                <th colspan="2">DURUM</th>
+                <td colspan="4">{{ status.code }}</td>
+            </tr>
+        </tbody>
+    </table>
+    {% if missing_fields %}
+    <div class="missing-fields">
+        <strong>Eksik Alanlar:</strong>
+        <ul>
+            {% for field in missing_fields %}
+            <li>{{ field }}</li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+    <form method="post" action="{{ url_for('form_summary', form_no=form_no) }}" class="summary-actions">
+        <input type="hidden" name="action" value="next">
+        <button type="submit" class="button secondary" data-action="submit-step" data-value="previous">← Geri</button>
+        <button type="submit" class="button save" data-action="submit-step" data-value="save">💾 Kaydet</button>
+    </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a Flask application under `web_app/` with session-backed multi-step form routes for creating, editing, and summarising records via `core.form_service`
- implement HTML templates and CSS assets for each wizard step plus the summary table, mirroring the Tkinter layout and status colour logic
- provide a home menu and .gitignore entries to handle generated Excel/config files and caches

## Testing
- pytest
- Manual: launched Flask dev server and completed the multi-step form in a browser

------
https://chatgpt.com/codex/tasks/task_b_68db1bec9e7c832fa7f094b08dc82a94