### PR TITLE
Fix encoding and improve responsive UX

### DIFF
--- a/core/form_service.py
+++ b/core/form_service.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Servis katmanı: Görev formu veri işlemleri."""
 from __future__ import annotations
 

--- a/web_app/static/styles.css
+++ b/web_app/static/styles.css
@@ -248,8 +248,15 @@ body {
 }
 
 .form-card.form-scroll {
-    max-height: 600px;
+    max-height: clamp(420px, 80vh, 640px);
     overflow-y: auto;
+}
+
+@media (max-width: 768px) {
+    .form-card.form-scroll {
+        max-height: none;
+        overflow-y: visible;
+    }
 }
 
 .form-row {
@@ -351,10 +358,16 @@ body {
     color: #555;
 }
 
+.summary-table-wrapper {
+    width: 100%;
+    overflow-x: auto;
+}
+
 .summary-table {
     width: 100%;
     border-collapse: collapse;
     background: #fff;
+    min-width: 720px;
 }
 
 .summary-table th,

--- a/web_app/templates/steps/saat_bilgileri.html
+++ b/web_app/templates/steps/saat_bilgileri.html
@@ -19,35 +19,35 @@
     <div class="grid grid-2">
         <div class="form-row">
             <label for="yola_cikis_tarih">Yola Çıkış Tarihi</label>
-            <input id="yola_cikis_tarih" name="yola_cikis_tarih" type="text" value="{{ form_data.get('yola_cikis_tarih', '') }}" placeholder="GG.AA.YYYY">
+            <input id="yola_cikis_tarih" name="yola_cikis_tarih" type="date" value="{{ form_data.get('yola_cikis_tarih', '') | to_html_date }}">
         </div>
         <div class="form-row">
             <label for="yola_cikis_saat">Yola Çıkış Saati</label>
-            <input id="yola_cikis_saat" name="yola_cikis_saat" type="text" value="{{ form_data.get('yola_cikis_saat', '') }}" placeholder="SS:DD">
+            <input id="yola_cikis_saat" name="yola_cikis_saat" type="time" value="{{ form_data.get('yola_cikis_saat', '') }}">
         </div>
         <div class="form-row">
             <label for="donus_tarih">Dönüş Tarihi</label>
-            <input id="donus_tarih" name="donus_tarih" type="text" value="{{ form_data.get('donus_tarih', '') }}" placeholder="GG.AA.YYYY">
+            <input id="donus_tarih" name="donus_tarih" type="date" value="{{ form_data.get('donus_tarih', '') | to_html_date }}">
         </div>
         <div class="form-row">
             <label for="donus_saat">Dönüş Saati</label>
-            <input id="donus_saat" name="donus_saat" type="text" value="{{ form_data.get('donus_saat', '') }}" placeholder="SS:DD">
+            <input id="donus_saat" name="donus_saat" type="time" value="{{ form_data.get('donus_saat', '') }}">
         </div>
         <div class="form-row">
             <label for="calisma_baslangic_tarih">Çalışma Başlangıç Tarihi</label>
-            <input id="calisma_baslangic_tarih" name="calisma_baslangic_tarih" type="text" value="{{ form_data.get('calisma_baslangic_tarih', '') }}" placeholder="GG.AA.YYYY">
+            <input id="calisma_baslangic_tarih" name="calisma_baslangic_tarih" type="date" value="{{ form_data.get('calisma_baslangic_tarih', '') | to_html_date }}">
         </div>
         <div class="form-row">
             <label for="calisma_baslangic_saat">Çalışma Başlangıç Saati</label>
-            <input id="calisma_baslangic_saat" name="calisma_baslangic_saat" type="text" value="{{ form_data.get('calisma_baslangic_saat', '') }}" placeholder="SS:DD">
+            <input id="calisma_baslangic_saat" name="calisma_baslangic_saat" type="time" value="{{ form_data.get('calisma_baslangic_saat', '') }}">
         </div>
         <div class="form-row">
             <label for="calisma_bitis_tarih">Çalışma Bitiş Tarihi</label>
-            <input id="calisma_bitis_tarih" name="calisma_bitis_tarih" type="text" value="{{ form_data.get('calisma_bitis_tarih', '') }}" placeholder="GG.AA.YYYY">
+            <input id="calisma_bitis_tarih" name="calisma_bitis_tarih" type="date" value="{{ form_data.get('calisma_bitis_tarih', '') | to_html_date }}">
         </div>
         <div class="form-row">
             <label for="calisma_bitis_saat">Çalışma Bitiş Saati</label>
-            <input id="calisma_bitis_saat" name="calisma_bitis_saat" type="text" value="{{ form_data.get('calisma_bitis_saat', '') }}" placeholder="SS:DD">
+            <input id="calisma_bitis_saat" name="calisma_bitis_saat" type="time" value="{{ form_data.get('calisma_bitis_saat', '') }}">
         </div>
         <div class="form-row">
             <label for="mola_suresi">Toplam Mola (dakika)</label>

--- a/web_app/templates/summary.html
+++ b/web_app/templates/summary.html
@@ -31,8 +31,9 @@
             <div class="meta-row"><span>REV.NO/TRH</span><strong>{{ form_data.get('rev_no', '-') or '-' }}</strong></div>
         </div>
     </div>
-    <table class="summary-table">
-        <tbody>
+    <div class="summary-table-wrapper">
+        <table class="summary-table">
+            <tbody>
             <tr class="section">
                 <th colspan="2">GÖREVLİ PERSONEL</th>
                 <th colspan="2">AVANS TUTARI</th>
@@ -105,8 +106,9 @@
                 <th colspan="2">DURUM</th>
                 <td colspan="4">{{ status.code }}</td>
             </tr>
-        </tbody>
-    </table>
+            </tbody>
+        </table>
+    </div>
     {% if missing_fields %}
     <div class="missing-fields">
         <strong>Eksik Alanlar:</strong>


### PR DESCRIPTION
## Summary
- ensure python modules declare UTF-8 encoding so Turkish strings render correctly
- add HTML5 date/time handling and normalization for the hour entry step
- make summary table and scrollable card responsive for smaller viewports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68db256a6b68832f81c1a98a8e1ab507