### PR TITLE
Add admin panel for managing dropdown data

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,0 +1,28 @@
+{
+  "personel_options": [
+    "Ahmet Yılmaz",
+    "Mehmet Demir",
+    "Ali Kaya",
+    "Veli Çelik",
+    "Hasan Şahin",
+    "Hüseyin Aydın",
+    "İbrahim Özdemir",
+    "Mustafa Arslan",
+    "Emre Doğan",
+    "Burak Yıldız"
+  ],
+  "taseron_options": [
+    "Yok",
+    "ABC İnşaat",
+    "XYZ Teknik",
+    "Marmara Mühendislik",
+    "Anadolu Yapı"
+  ],
+  "hazirlayan_options": [
+    "Ali Yılmaz",
+    "Ayşe Demir",
+    "Mehmet Korkmaz",
+    "Zeynep Ak",
+    "Elif Kaya"
+  ]
+}

--- a/web_app/static/styles.css
+++ b/web_app/static/styles.css
@@ -110,7 +110,8 @@ body {
 }
 
 .menu-card.accent-blue::before,
-.menu-card.accent-yellow::before {
+.menu-card.accent-yellow::before,
+.menu-card.accent-green::before {
     content: '';
     position: absolute;
     inset: 0;
@@ -124,6 +125,10 @@ body {
 
 .menu-card.accent-yellow::before {
     background: linear-gradient(135deg, #fff176, var(--secondary));
+}
+
+.menu-card.accent-green::before {
+    background: linear-gradient(135deg, #a5d6a7, var(--success));
 }
 
 .menu-card .button {
@@ -247,6 +252,11 @@ body {
     margin-bottom: 40px;
 }
 
+.form-card.narrow {
+    max-width: 420px;
+    margin: 0 auto 40px;
+}
+
 .form-card.form-scroll {
     max-height: clamp(420px, 80vh, 640px);
     overflow-y: auto;
@@ -282,6 +292,23 @@ body {
 .form-row textarea {
     min-height: 160px;
     resize: vertical;
+}
+
+.stacked {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.stacked label {
+    font-weight: 600;
+}
+
+.stacked input,
+.stacked textarea,
+.stacked button,
+.stacked select {
+    width: 100%;
 }
 
 .form-actions {

--- a/web_app/templates/admin.html
+++ b/web_app/templates/admin.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block title %}Admin Paneli · Görev Formu Sistemi{% endblock %}
+
+{% block content %}
+<h2>🛠️ Admin Paneli</h2>
+<p>Buradan açılır menülerde kullanılan verileri düzenleyebilir veya yeni bir JSON dosyası yükleyebilirsiniz.</p>
+
+<section class="form-card">
+    <h3>Listeleri Düzenle</h3>
+    <form method="post" action="{{ url_for('admin_update') }}" class="stacked">
+        <label for="personel_options">Personel Listesi (her satıra bir değer)</label>
+        <textarea id="personel_options" name="personel_options" rows="8">{{ data.personel_options | join('\n') }}</textarea>
+
+        <label for="taseron_options">Taşeron Şirketler</label>
+        <textarea id="taseron_options" name="taseron_options" rows="6">{{ data.taseron_options | join('\n') }}</textarea>
+
+        <label for="hazirlayan_options">Hazırlayan / Görevlendiren</label>
+        <textarea id="hazirlayan_options" name="hazirlayan_options" rows="6">{{ data.hazirlayan_options | join('\n') }}</textarea>
+
+        <button type="submit" class="button save">💾 Değişiklikleri Kaydet</button>
+    </form>
+</section>
+
+<section class="form-card">
+    <h3>JSON Dosyası Yükle</h3>
+    <p>"personel_options", "taseron_options" ve "hazirlayan_options" anahtarlarını içeren bir JSON dosyası yükleyerek verileri toplu olarak güncelleyebilirsiniz.</p>
+    <form method="post" action="{{ url_for('admin_upload') }}" enctype="multipart/form-data" class="stacked">
+        <input type="file" name="data_file" accept="application/json" required>
+        <button type="submit" class="button secondary">📁 Dosyayı Yükle</button>
+    </form>
+</section>
+
+<a class="button" href="{{ url_for('admin_logout') }}">Çıkış Yap</a>
+{% endblock %}

--- a/web_app/templates/admin_login.html
+++ b/web_app/templates/admin_login.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block title %}Admin Girişi · Görev Formu Sistemi{% endblock %}
+
+{% block content %}
+<div class="form-card narrow">
+    <h2>🔐 Admin Paneli</h2>
+    <p>Admin paneline erişmek için şifreyi girin.</p>
+    <form method="post" action="{{ url_for('admin_panel') }}" class="stacked">
+        <label for="password">Şifre</label>
+        <input type="password" id="password" name="password" placeholder="Admin şifresi" required>
+        <button type="submit" class="button primary">Giriş Yap</button>
+    </form>
+</div>
+{% endblock %}

--- a/web_app/templates/base.html
+++ b/web_app/templates/base.html
@@ -16,6 +16,10 @@
             <a href="{{ url_for('form_wizard', form_no=form_no, step=0) }}">Form {{ form_no }}</a>
             <a href="{{ url_for('form_summary', form_no=form_no) }}">Özet</a>
             {% endif %}
+            <a href="{{ url_for('admin_panel') }}">Admin Paneli</a>
+            {% if is_admin %}
+            <a href="{{ url_for('admin_logout') }}">Çıkış</a>
+            {% endif %}
         </nav>
     </div>
 </header>

--- a/web_app/templates/home.html
+++ b/web_app/templates/home.html
@@ -24,5 +24,10 @@
             <button type="submit" class="button secondary">Formu Aç</button>
         </form>
     </div>
+    <div class="menu-card accent-green">
+        <h2>🛠️ Admin Paneli</h2>
+        <p>Açılır menülerdeki gerçek verileri görüntüleyin, düzenleyin veya yeni JSON dosyası yükleyin.</p>
+        <a class="button" href="{{ url_for('admin_panel') }}">Admin Panelini Aç</a>
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- load dropdown option lists from a shared `data.json` file with helper utilities
- add password-protected admin panel to review, edit, and upload dropdown data
- expose admin access from the home page and enhance styling for the new views

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68db2bfece6c832fb6cfebce5f0b83bc