### PR TITLE
Ensure logo asset is user-provided

### DIFF
--- a/web_app/static/styles.css
+++ b/web_app/static/styles.css
@@ -32,9 +32,20 @@ body {
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
 }
 
+.app-brand {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 16px 0 8px;
+}
+
+.app-logo {
+    height: 48px;
+    width: auto;
+}
+
 .app-header h1 {
     margin: 0;
-    padding: 20px 0 10px;
     color: var(--danger);
     font-size: 1.6rem;
 }

--- a/web_app/templates/base.html
+++ b/web_app/templates/base.html
@@ -9,7 +9,10 @@
 <body>
 <header class="app-header">
     <div class="container">
-        <h1>🔧 Delta Proje &mdash; Görev Formu Sistemi</h1>
+        <div class="app-brand">
+            <img src="{{ url_for('static', filename='images/delta_logo.png') }}" alt="Delta Proje logosu" class="app-logo">
+            <h1>Delta Proje &mdash; Görev Formu Sistemi</h1>
+        </div>
         <nav>
             <a href="{{ url_for('index') }}">Ana Menü</a>
             {% if form_no %}


### PR DESCRIPTION
## Summary
- remove the previously committed binary logo asset so it can be supplied out of band
- retain the header template and styles that reference the logo path for when the asset is provided

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_b_68db301ef2f4832f95a22430ec531404