### PR TITLE
Add dynamic vehicle plate options support

### DIFF
--- a/web_app/__init__.py
+++ b/web_app/__init__.py
@@ -85,6 +85,13 @@ DEFAULT_DYNAMIC_DATA: Dict[str, List[str]] = {
         "Zeynep Ak",
         "Elif Kaya",
     ],
+    "arac_plaka_options": [
+        "34 ABC 123",
+        "34 XYZ 456",
+        "06 DEF 789",
+        "16 GHI 321",
+        "35 JKL 654",
+    ],
 }
 
 _dynamic_data: Dict[str, List[str]] | None = None
@@ -199,6 +206,7 @@ def register_routes(app: Flask) -> None:
             "personel_options": dynamic_data["personel_options"],
             "taseron_options": dynamic_data["taseron_options"],
             "hazirlayan_options": dynamic_data["hazirlayan_options"],
+            "arac_plaka_options": dynamic_data["arac_plaka_options"],
             "is_admin": is_admin(),
         }
 
@@ -279,6 +287,7 @@ def register_routes(app: Flask) -> None:
             personel_options=dynamic_data["personel_options"],
             taseron_options=dynamic_data["taseron_options"],
             hazirlayan_options=dynamic_data["hazirlayan_options"],
+            arac_plaka_options=dynamic_data["arac_plaka_options"],
         )
 
     @app.route("/form/<form_no>/summary", methods=["GET", "POST"])

--- a/web_app/templates/admin.html
+++ b/web_app/templates/admin.html
@@ -17,13 +17,16 @@
         <label for="hazirlayan_options">Hazırlayan / Görevlendiren</label>
         <textarea id="hazirlayan_options" name="hazirlayan_options" rows="6">{{ data.hazirlayan_options | join('\n') }}</textarea>
 
+        <label for="arac_plaka_options">Araç Plaka Listesi</label>
+        <textarea id="arac_plaka_options" name="arac_plaka_options" rows="6">{{ data.arac_plaka_options | join('\n') }}</textarea>
+
         <button type="submit" class="button save">💾 Değişiklikleri Kaydet</button>
     </form>
 </section>
 
 <section class="form-card">
     <h3>JSON Dosyası Yükle</h3>
-    <p>"personel_options", "taseron_options" ve "hazirlayan_options" anahtarlarını içeren bir JSON dosyası yükleyerek verileri toplu olarak güncelleyebilirsiniz.</p>
+    <p>"personel_options", "taseron_options", "hazirlayan_options" ve "arac_plaka_options" anahtarlarını içeren bir JSON dosyası yükleyerek verileri toplu olarak güncelleyebilirsiniz.</p>
     <form method="post" action="{{ url_for('admin_upload') }}" enctype="multipart/form-data" class="stacked">
         <input type="file" name="data_file" accept="application/json" required>
         <button type="submit" class="button secondary">📁 Dosyayı Yükle</button>

--- a/web_app/templates/steps/arac_bilgisi.html
+++ b/web_app/templates/steps/arac_bilgisi.html
@@ -18,7 +18,16 @@
     <input type="hidden" name="action" value="next">
     <div class="form-row">
         <label for="arac_plaka">Araç Plaka No</label>
-        <input id="arac_plaka" name="arac_plaka" type="text" value="{{ form_data.get('arac_plaka', '') }}" placeholder="34 ABC 123">
+        {% set current_value = form_data.get('arac_plaka', '') %}
+        <select id="arac_plaka" name="arac_plaka">
+            <option value="">Bir araç seçin</option>
+            {% for option in arac_plaka_options %}
+                <option value="{{ option }}" {{ 'selected' if option == current_value else '' }}>{{ option }}</option>
+            {% endfor %}
+            {% if current_value and current_value not in arac_plaka_options %}
+                <option value="{{ current_value }}" selected>{{ current_value }}</option>
+            {% endif %}
+        </select>
     </div>
     <div class="form-actions">
         <button type="submit" class="button secondary" data-action="submit-step" data-value="previous">← Geri</button>


### PR DESCRIPTION
## Summary
- add default vehicle plate options and make them available to templates
- extend the admin panel to edit and import vehicle plate option lists
- replace the vehicle plate text field with a select populated from dynamic data

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'openpyxl')*


------
https://chatgpt.com/codex/tasks/task_b_68db354ed138832f8b6acd2604a81098