### PR TITLE
Add deployment entry point for Render hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ tests/               # Pytest senaryoları
 ## Web Uygulamasını Çalıştırma
 1. Proje klasöründe aşağıdaki komutla geliştirme sunucusunu başlatın:
    ```bash
-   flask --app web_app run --debug
+   flask --app web_app run --debug --host=0.0.0.0
    ```
-   Alternatif olarak `python -m flask --app web_app run` kullanabilirsiniz.
+   Alternatif olarak `python -m flask --app web_app run --host=0.0.0.0`
+   kullanabilirsiniz.
 2. Tarayıcınızda [http://localhost:5000](http://localhost:5000) adresine gidin.
 3. Ana ekrandan yeni form başlatabilir veya mevcut bir form numarasını girerek düzenlemeye devam edebilirsiniz.
 
@@ -55,3 +56,18 @@ senaryoları mevcuttur. Testleri çalıştırmak için:
 ```bash
 pytest
 ```
+
+## Render (ve benzeri platformlarda) Yayınlama
+
+Render gibi barındırma platformları uygulamanın `0.0.0.0` adresine bağlanmasını
+ve kendilerinin tanımladığı `PORT` ortam değişkenini dinlemesini bekler. Bu
+proje için başlangıç komutunu aşağıdaki gibi tanımlayabilirsiniz:
+
+```bash
+python -m web_app
+```
+
+Komut, `web_app` paketindeki yeni komut satırı giriş noktasını kullanarak Flask
+uygulamasını doğru host ve port ayarlarıyla başlatır. Geliştirme ortamında da
+aynı komutu kullanabilirsiniz; `FLASK_DEBUG=1` gibi bir değişken tanımladığınızda
+otomatik olarak debug modu açılır.

--- a/web_app/__main__.py
+++ b/web_app/__main__.py
@@ -1,0 +1,40 @@
+"""Command line entry point for running the Flask app.
+
+This module makes it easy to run the application with ``python -m web_app``
+which is handy for deployment platforms (e.g. Render) that expect the
+process to bind to ``0.0.0.0`` and respect the ``PORT`` environment
+variable.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from . import create_app
+
+
+def _get_port(default: int = 5000) -> int:
+    raw_port = os.environ.get("PORT", str(default))
+    try:
+        return int(raw_port)
+    except (TypeError, ValueError):
+        return default
+
+
+def _get_debug_flag(default: bool = False) -> bool:
+    raw_value: Any = os.environ.get("FLASK_DEBUG") or os.environ.get("DEBUG")
+    if raw_value is None:
+        return default
+    return str(raw_value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def main() -> None:
+    app = create_app()
+    host = os.environ.get("HOST", "0.0.0.0")
+    port = _get_port()
+    debug = _get_debug_flag()
+    app.run(host=host, port=port, debug=debug)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `python -m web_app` entry point that binds the Flask server to 0.0.0.0 and respects the PORT env var
- document the new command and Render deployment instructions in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68db391ec4c4832fbfaf5f3c62a16824