### PR TITLE
Document Render start command for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ pytest
 ## Render (ve benzeri platformlarda) Yayınlama
 
 Render gibi barındırma platformları uygulamanın `0.0.0.0` adresine bağlanmasını
-ve kendilerinin tanımladığı `PORT` ortam değişkenini dinlemesini bekler. Bu
-proje için başlangıç komutunu aşağıdaki gibi tanımlayabilirsiniz:
+ve kendilerinin tanımladığı `PORT` ortam değişkenini dinlemesini bekler. Render
+dashboard'ında **Start Command** alanına aşağıdaki komutu yazdığınızdan emin olun:
 
 ```bash
 python -m web_app
 ```
 
-Komut, `web_app` paketindeki yeni komut satırı giriş noktasını kullanarak Flask
+Bu komut, `web_app` paketindeki yeni komut satırı giriş noktasını kullanarak Flask
 uygulamasını doğru host ve port ayarlarıyla başlatır. Geliştirme ortamında da
 aynı komutu kullanabilirsiniz; `FLASK_DEBUG=1` gibi bir değişken tanımladığınızda
 otomatik olarak debug modu açılır.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: web
+    name: delta-gorev-formu
+    env: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: python -m web_app


### PR DESCRIPTION
## Summary
- add a render.yaml template configuring the service to run with `python -m web_app`
- clarify the README instructions to set Render's Start Command to the same entry point

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68db8ef92000832f91053c68c42b852f