### PR TITLE
Configure Render deployment for gunicorn

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,4 +3,4 @@ services:
     name: delta-gorev-formu
     env: python
     buildCommand: pip install -r requirements.txt
-    startCommand: python -m web_app
+    startCommand: gunicorn --bind 0.0.0.0:$PORT 'web_app:app'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask>=3.0,<4.0
 openpyxl>=3.1,<4.0
 pytest>=8.0,<9.0
+gunicorn>=20.1,<21.0


### PR DESCRIPTION
## Summary
- add the gunicorn dependency required for serving the Flask app in production
- update the Render start command to launch gunicorn bound to 0.0.0.0:$PORT

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68db924ec150832f90f6f46df2a679e2